### PR TITLE
Implement snapshot server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ useradd -r -g hyperliquid -u 10001 -d /home/hyperliquid -s /bin/bash hyperliquid
 
 # Create base directory structure
 install -d -m 755 -o root -g root /opt/hl
-install -d -m 755 -o hyperliquid -g hyperliquid /home/hyperliquid /data /data/hl /data/hl/data /opt/hl/bin
+install -d -m 755 -o hyperliquid -g hyperliquid /home/hyperliquid /data /data/hl /data/hl/data /data/snapshots /opt/hl/bin
 ln -s /data/hl /home/hyperliquid/hl
 EOF
 
@@ -79,6 +79,7 @@ USER hyperliquid:hyperliquid
 
 VOLUME /opt/hl/bin
 VOLUME /data
+VOLUME /data/snapshots
 WORKDIR /data
 
 # Import Hypqliquid public key. This is also required by hl-visor to verify downloaded binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,10 +95,17 @@ ENV HL_BOOTSTRAP_OVERRIDE_GOSSIP_CONFIG_MAX_AGE=15m
 ENV HL_BOOTSTRAP_SEED_PEERS_AMOUNT=5
 ENV HL_BOOTSTRAP_SEED_PEERS_MAX_LATENCY=80ms
 ENV HL_BOOTSTRAP_NETWORK=Mainnet
+ENV HL_BOOTSTRAP_METRICS_LISTEN_ADDRESS=0.0.0.0:2112
+ENV HL_BOOTSTRAP_SNAPSHOT_SERVER_LISTEN_ADDRESS=0.0.0.0:2113
 
 # RPC
 EXPOSE 3001/tcp
 # P2P
 EXPOSE 4000-4010/tcp
+# Metrics
+EXPOSE 2112/tcp
+# Snapshot server
+EXPOSE 2113/tcp
+
 ENTRYPOINT ["/usr/bin/catatonit", "--", "hl-bootstrap", "--override-gossip-config-path=/data/override_gossip_config.json", "--"]
 CMD ["run-non-validator", "--write-trades", "--write-fills", "--write-order-statuses", "--serve-eth-rpc", "--serve-info", "--disable-output-file-buffering"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,7 @@ services:
     volumes:
       - "node-bin:/opt/hl/bin"
       - "node-data:/data"
+      - "node-snapshot:/data/snapshot"
     ports:
       - "127.0.0.1:3001:3001"
       - "0.0.0.0:4000-4010:4000-4010"
@@ -41,3 +42,4 @@ services:
 volumes:
   node-bin: {}
   node-data: {}
+  node-snapshot: {}

--- a/hl-bootstrap/Cargo.lock
+++ b/hl-bootstrap/Cargo.lock
@@ -90,6 +90,7 @@ checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -104,6 +105,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -316,6 +319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,8 +397,10 @@ dependencies = [
  "structstruck",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "which",
 ]
 
@@ -1157,18 +1168,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1185,6 +1206,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1413,6 +1445,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1603,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/hl-bootstrap/Cargo.toml
+++ b/hl-bootstrap/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 axum = { version = "0.8.4", default-features = false, features = [
     "tokio",
     "http1",
+    "query",
 ] }
 clap = { version = "4.5.41", features = ["env", "derive"] }
 duration-string = "0.5.2"
@@ -28,6 +29,8 @@ tokio = { version = "1.46.1", features = [
     "rt",
     "rt-multi-thread",
 ] }
+tokio-util = { version = "0.7.18", features = ["io"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+uuid = { version = "1.19.0", features = ["serde", "v7"] }
 which = { version = "8.0.0", features = ["tracing"] }

--- a/hl-bootstrap/src/axum_ext.rs
+++ b/hl-bootstrap/src/axum_ext.rs
@@ -1,0 +1,31 @@
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+use tracing::error;
+
+pub struct Report(eyre::Report);
+
+pub type HttpResult<T, E = Report> = eyre::Result<T, E>;
+
+impl std::fmt::Debug for Report {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<E> From<E> for Report
+where
+    E: Into<eyre::Report>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}
+
+impl IntoResponse for Report {
+    fn into_response(self) -> Response {
+        let err = self.0;
+
+        error!(?err, "http handler error");
+        (StatusCode::INTERNAL_SERVER_ERROR, format!("{err:?}")).into_response()
+    }
+}

--- a/hl-bootstrap/src/prune.rs
+++ b/hl-bootstrap/src/prune.rs
@@ -11,7 +11,7 @@ pub async fn prune_worker_task<P: AsRef<Path>>(
     prune_interval: Duration,
     prune_older_than: Duration,
 ) {
-    let base_path = base_path.as_ref().join("hl/data");
+    let base_path = base_path.as_ref();
 
     let mut interval = interval(prune_interval);
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);

--- a/hl-bootstrap/src/snapshot/mod.rs
+++ b/hl-bootstrap/src/snapshot/mod.rs
@@ -1,0 +1,56 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use uuid::Uuid;
+
+pub mod server;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum FileSnapshotType {
+    #[serde(rename = "l4Snapshots")]
+    L4Snapshots {
+        #[serde(rename = "includeUsers", default)]
+        include_users: bool,
+
+        #[serde(rename = "includeTriggerOrders", default)]
+        include_trigger_orders: bool,
+    },
+    #[serde(rename = "referrerStates")]
+    ReferrerStates,
+}
+
+impl FileSnapshotType {
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Self::L4Snapshots { .. } => "l4Snapshots",
+            Self::ReferrerStates => "referrerStates",
+        }
+    }
+}
+
+pub fn create_file_snapshot_path(
+    base: impl AsRef<Path>,
+    snapshot_request: &FileSnapshotType,
+) -> PathBuf {
+    let snapshot_id = Uuid::now_v7();
+    base.as_ref().join(format!(
+        "{}_{}.json",
+        snapshot_request.type_name(),
+        snapshot_id
+    ))
+}
+
+pub fn create_file_snapshot_payload(
+    snapshot_request: &FileSnapshotType,
+    include_height_in_output: bool,
+    out_path: impl AsRef<Path>,
+) -> serde_json::Value {
+    json!({
+        "type": "fileSnapshot",
+        "request": snapshot_request,
+        "includeHeightInOutput": include_height_in_output,
+        "outPath": out_path.as_ref().to_string_lossy(),
+    })
+}

--- a/hl-bootstrap/src/snapshot/server.rs
+++ b/hl-bootstrap/src/snapshot/server.rs
@@ -78,13 +78,11 @@ async fn snapshot(
 }
 
 pub async fn run_snapshot_server(
-    data_dir: impl AsRef<Path>,
+    snapshot_directory: impl AsRef<Path>,
     listen_address: SocketAddr,
 ) -> eyre::Result<()> {
     let state = SnapshotServer {
-        // TODO: should not create files under hl/data
-        // Configure pruner to look into our managed directory instead.
-        snapshot_directory: data_dir.as_ref().join("hl/data/hl_bootstrap_snapshots"),
+        snapshot_directory: snapshot_directory.as_ref().into(),
     };
 
     let listener = TcpListener::bind(listen_address).await?;

--- a/hl-bootstrap/src/snapshot/server.rs
+++ b/hl-bootstrap/src/snapshot/server.rs
@@ -1,0 +1,94 @@
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::extract::Query;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Router, extract::State};
+use reqwest::{Client, ClientBuilder, StatusCode};
+use serde::Deserialize;
+use tokio::fs::File;
+use tokio::net::TcpListener;
+use tokio_util::io::ReaderStream;
+
+use crate::axum_ext::HttpResult;
+
+static CLIENT: LazyLock<Client> = LazyLock::new(|| ClientBuilder::new().build().unwrap());
+
+#[derive(Clone)]
+struct SnapshotServer {
+    snapshot_directory: PathBuf,
+}
+
+fn router() -> Router<SnapshotServer> {
+    Router::new().route("/snapshot", get(snapshot))
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapshotRequest {
+    #[serde(flatten)]
+    snapshot: super::FileSnapshotType,
+
+    #[serde(
+        rename = "includeHeightInOutput",
+        default = "default_include_height_in_output"
+    )]
+    include_height_in_output: bool,
+}
+
+fn default_include_height_in_output() -> bool {
+    true
+}
+
+async fn snapshot(
+    State(state): State<SnapshotServer>,
+    Query(SnapshotRequest {
+        snapshot,
+        include_height_in_output,
+    }): Query<SnapshotRequest>,
+) -> HttpResult<impl IntoResponse> {
+    let snapshot_path = super::create_file_snapshot_path(&state.snapshot_directory, &snapshot);
+    let payload =
+        super::create_file_snapshot_payload(&snapshot, include_height_in_output, &snapshot_path);
+
+    let _response = CLIENT
+        .post("http://127.0.0.1:3001/info")
+        .json(&payload)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    // TODO: assert response
+
+    // TODO: unsure if this is needed
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let stream = ReaderStream::new(File::open(snapshot_path).await?);
+
+    Ok((
+        StatusCode::OK,
+        [(CONTENT_TYPE, "application/json")],
+        Body::from_stream(stream),
+    )
+        .into_response())
+}
+
+pub async fn run_snapshot_server(
+    data_dir: impl AsRef<Path>,
+    listen_address: SocketAddr,
+) -> eyre::Result<()> {
+    let state = SnapshotServer {
+        // TODO: should not create files under hl/data
+        // Configure pruner to look into our managed directory instead.
+        snapshot_directory: data_dir.as_ref().join("hl/data/hl_bootstrap_snapshots"),
+    };
+
+    let listener = TcpListener::bind(listen_address).await?;
+    axum::serve(listener, router().with_state(state).into_make_service()).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
hl-node does not allow `fileSnapshot` requests from non-localhost IPs. This implements a small streaming proxy server to request file snapshots from.

Created snapshots will have unique names on disk, which pruner will clean up rather fast and contents will be streamed over HTTP response for ease of use.